### PR TITLE
Prevent Evergreen from trying to get patron dumps

### DIFF
--- a/api/evergreen_patron.py
+++ b/api/evergreen_patron.py
@@ -231,6 +231,8 @@ class EvergreenPatronAPI(BasicAuthAuthenticator, XMLParser):
         # no authenticated patron.
         if not self.pintest(identifier, password):
             return None
+        else:
+            return Patron()
 
         now = datetime.datetime.utcnow()
 


### PR DESCRIPTION
This is something that Millennium supports but Evergreen
does not. Trying to do it in evergreen causes errors and 
failure during login so our workaround is to not bother doing
it when authenticating with Evergreen. 

This is intended to be a temporary workaround which should
be overridden by NYPL's official Evergreen changes