### PR TITLE
Change cairosvg to use 1.0.22

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-dateutil
 uwsgi
 loggly-python-handler
 mock
-cairosvg
+cairosvg==1.0.22
 py-bcrypt
 Flask-Babel
 


### PR DESCRIPTION
The newest version dropped support for python 2 which causes
the docker file build to fail