### PR TITLE
Add Enki to circulation

### DIFF
--- a/api/circulation.py
+++ b/api/circulation.py
@@ -182,8 +182,8 @@ class CirculationAPI(object):
             api = self.threem
         elif licensepool.data_source.name==DataSource.AXIS_360:
             api = self.axis
-        #elif licensepool.data_source.name==DataSource.ENKI:
-            #api = self.enki
+        elif licensepool.data_source.name==DataSource.ENKI:
+            api = self.enki
         else:
             return None
 

--- a/api/circulation.py
+++ b/api/circulation.py
@@ -130,12 +130,13 @@ class CirculationAPI(object):
     between different circulation APIs.
     """
 
-    def __init__(self, _db, overdrive=None, threem=None, axis=None):
+    def __init__(self, _db, overdrive=None, threem=None, axis=None, enki=None):
         self._db = _db
         self.overdrive = overdrive
         self.threem = threem
         self.axis = axis
-        self.apis = [x for x in (overdrive, threem, axis) if x]
+        self.enki = enki
+        self.apis = [x for x in (overdrive, threem, axis, enki) if x]
         self.log = logging.getLogger("Circulation API")
 
         # When we get our view of a patron's loans and holds, we need
@@ -154,6 +155,10 @@ class CirculationAPI(object):
         if self.axis:
             data_sources_for_sync.append(
                 DataSource.lookup(_db, DataSource.AXIS_360)
+            )
+        if self.enki:
+            data_sources_for_sync.append(
+                DataSource.lookup(_db, DataSource.ENKI)
             )
 
 
@@ -177,6 +182,8 @@ class CirculationAPI(object):
             api = self.threem
         elif licensepool.data_source.name==DataSource.AXIS_360:
             api = self.axis
+        #elif licensepool.data_source.name==DataSource.ENKI:
+            #api = self.enki
         else:
             return None
 

--- a/api/controller.py
+++ b/api/controller.py
@@ -114,7 +114,7 @@ from adobe_vendor_id import (
 from axis import Axis360API
 from overdrive import OverdriveAPI
 from threem import ThreeMAPI
-#from enki import EnkiAPI
+from enki import EnkiAPI
 from circulation import CirculationAPI
 from novelist import (
     NoveListAPI,
@@ -221,8 +221,8 @@ class CirculationManager(object):
                 _db=self._db, 
                 threem=threem, 
                 overdrive=overdrive,
-                axis=axis#,
-                #enki=enki
+                axis=axis,
+                enki=enki
             )
 
     def setup_controllers(self):

--- a/api/controller.py
+++ b/api/controller.py
@@ -114,6 +114,7 @@ from adobe_vendor_id import (
 from axis import Axis360API
 from overdrive import OverdriveAPI
 from threem import ThreeMAPI
+#from enki import EnkiAPI
 from circulation import CirculationAPI
 from novelist import (
     NoveListAPI,
@@ -220,7 +221,8 @@ class CirculationManager(object):
                 _db=self._db, 
                 threem=threem, 
                 overdrive=overdrive,
-                axis=axis
+                axis=axis#,
+                #enki=enki
             )
 
     def setup_controllers(self):

--- a/api/controller.py
+++ b/api/controller.py
@@ -217,6 +217,7 @@ class CirculationManager(object):
             overdrive = OverdriveAPI.from_environment(self._db)
             threem = ThreeMAPI.from_environment(self._db)
             axis = Axis360API.from_environment(self._db)
+            enki = EnkiAPI.from_environment(self._db)
             self.circulation = CirculationAPI(
                 _db=self._db, 
                 threem=threem, 

--- a/api/coverage.py
+++ b/api/coverage.py
@@ -205,7 +205,8 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
                 Identifier.THREEM_ID,
                 Identifier.GUTENBERG_ID, 
                 Identifier.AXIS_360_ID,
-                Identifier.ONECLICK_ID, 
+                Identifier.ONECLICK_ID,
+                Identifier.ENKI_ID,
             ]
         output_source = DataSource.lookup(
             _db, DataSource.METADATA_WRANGLER
@@ -266,7 +267,7 @@ class MetadataWranglerCoverageProvider(OPDSImportCoverageProvider):
         """
         mapping = dict()
         for identifier in batch:
-            if identifier.type in [Identifier.AXIS_360_ID, Identifier.THREEM_ID, Identifier.ONECLICK_ID]:
+            if identifier.type in [Identifier.AXIS_360_ID, Identifier.THREEM_ID, Identifier.ONECLICK_ID, Identifier.ENKI_ID]:
                 for e in identifier.equivalencies:
                     if e.output.type == Identifier.ISBN:
                         mapping[e.output] = identifier

--- a/api/enki.py
+++ b/api/enki.py
@@ -1,0 +1,156 @@
+rom nose.tools import set_trace
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import contains_eager
+
+from lxml import etree
+from core.enki import (
+    EnkiAPI as BaseEnkiAPI,
+    MockEnkiAPI as BaseMockEnkiAPI,
+    EnkiParser,
+    BibliographicParser,
+    EnkiBibliographicCoverageProvider
+)
+
+from core.metadata_layer import (
+    CirculationData,
+    ReplacementPolicy,
+)
+
+from core.monitor import (
+    Monitor,
+    IdentifierSweepMonitor,
+)
+
+from core.opds_import import (
+    SimplifiedOPDSLookup,
+)
+
+from core.model import (
+    CirculationEvent,
+    get_one_or_create,
+    Contributor,
+    DataSource,
+    DeliveryMechanism,
+    Edition,
+    Identifier,
+    LicensePool,
+    Representation,
+    Subject,
+)
+
+from core.coverage import (
+    BibliographicCoverageProvider,
+    CoverageFailure,
+)
+
+from authenticator import Authenticator
+from config import Configuration
+from circulation import (
+    LoanInfo,
+    FulfillmentInfo,
+    HoldInfo,
+    BaseCirculationAPI
+)
+from circulation_exceptions import *
+
+#TODO: Remove unnecessary imports (once the classes are more or less complete)
+
+class EnkiAPI(BaseEnkiAPI, BaseCirculationAPI):
+    #TODO
+
+class EnkiCirculationMonitor(Monitor):
+    """Maintain LicensePools for Enki titles.
+    """
+
+    VERY_LONG_AGO = datetime(1970, 1, 1)
+    FIVE_MINUTES = timedelta(minutes=5)
+
+    def __init__(self, _db, name="Enki Circulation Monitor",
+                 interval_seconds=60, batch_size=50, api=None):
+        super(EnkiCirculationMonitor, self).__init__(
+            _db, name, interval_seconds=interval_seconds,
+            default_start_time = self.VERY_LONG_AGO
+        )
+        self.batch_size = batch_size
+        metadata_wrangler_url = Configuration.integration_url(
+                Configuration.METADATA_WRANGLER_INTEGRATION
+        )
+        if metadata_wrangler_url:
+            self.metadata_wrangler = SimplifiedOPDSLookup(metadata_wrangler_url)
+        else:
+            # This should only happen during a test.
+            self.metadata_wrangler = None
+        self.api = api or EnkiAPI.from_environment(self._db)
+        self.bibliographic_coverage_provider = (
+            EnkiBibliographicCoverageProvider(self._db, enki_api=api)
+        )
+
+    def run(self):
+        super(EnkiCirculationMonitor, self).run()
+
+    def run_once(self, start, cutoff):
+        # Give us five minutes of overlap because it's very important
+        # we don't miss anything.
+        since = start-self.FIVE_MINUTES
+        availability = self.api.availability(since=since)
+        status_code = availability.status_code
+        content = availability.content
+        count = 0
+        for bibliographic, circulation in BibliographicParser().process_all(
+                content):
+            self.process_book(bibliographic, circulation)
+            count += 1
+            if count % self.batch_size == 0:
+                self._db.commit()
+
+    def process_book(self, bibliographic, availability):
+
+        license_pool, new_license_pool = availability.license_pool(self._db)
+        edition, new_edition = bibliographic.edition(self._db)
+        license_pool.edition = edition
+        policy = ReplacementPolicy(
+            identifiers=False,
+            subjects=True,
+            contributions=True,
+            formats=True,
+        )
+        availability.apply(
+            pool=license_pool,
+            replace=policy,
+        )
+        if new_edition:
+            bibliographic.apply(edition, replace=policy)
+
+        if new_license_pool or new_edition:
+            # At this point we have done work equivalent to that done by
+            # the EnkiBibliographicCoverageProvider. Register that the
+            # work has been done so we don't have to do it again.
+            identifier = edition.primary_identifier
+            self.bibliographic_coverage_provider.handle_success(identifier)
+            self.bibliographic_coverage_provider.add_coverage_record_for(
+                identifier
+            )
+
+        return edition, license_pool
+
+class MockEnkiAPI(BaseMockEnkiAPI, EnkiAPI):
+    #TODO
+
+class EnkiCollectionReaper(IdentifierSweepMonitor):
+    #TODO
+
+class ResponseParser(EnkiParser):
+    #TODO??
+
+class CheckoutResponseParser(ResponseParser):
+    #TODO??
+
+class HoldResponseParser(ResponseParser):
+    #TODO??
+
+class HoldReleaseResponseParser(ResponseParser):
+    #TODO??
+
+class AvailabilityResponseParser(ResponseParser):
+    #TODO??

--- a/api/enki.py
+++ b/api/enki.py
@@ -70,7 +70,6 @@ class EnkiCirculationMonitor(Monitor):
 
     def __init__(self, _db, name="Enki Circulation Monitor",
                  interval_seconds=60, batch_size=50, api=None):
-        print "We made it to init in EnkiCircMonitor"
 	super(EnkiCirculationMonitor, self).__init__(
             _db, name, interval_seconds=interval_seconds,
             default_start_time = self.VERY_LONG_AGO
@@ -85,26 +84,19 @@ class EnkiCirculationMonitor(Monitor):
             # This should only happen during a test.
             self.metadata_wrangler = None
         self.api = api or EnkiAPI.from_environment(self._db)
-	print "api is %s" % api
-	print "from_environment is %s" % EnkiAPI.from_environment(self._db)
-	print "selfapi is %s" % self.api
         self.bibliographic_coverage_provider = (
             EnkiBibliographicCoverageProvider(self._db, enki_api=api)
         )
 
     def run(self):
-	print "Chris was here at run(self) calling super(CircMon)"
         super(EnkiCirculationMonitor, self).run()
 
     def run_once(self, start, cutoff):
         # Give us five minutes of overlap because it's very important
         # we don't miss anything.
         since = start-self.FIVE_MINUTES
-	print "Here is where we try and get availability"
         availability = self.api.availability(since=since)
-        #print "The response is: %s" % availability.content
 	status_code = availability.status_code
-	print "The status code is %s" % status_code 
         content = availability.content
         count = 0
         for bibliographic, circulation in BibliographicParser().process_all(

--- a/api/enki.py
+++ b/api/enki.py
@@ -102,7 +102,7 @@ class EnkiCirculationMonitor(Monitor):
         since = start-self.FIVE_MINUTES
 	print "Here is where we try and get availability"
         availability = self.api.availability(since=since)
-        print "The response is: %s" % availability.content
+        #print "The response is: %s" % availability.content
 	status_code = availability.status_code
 	print "The status code is %s" % status_code 
         content = availability.content

--- a/api/services.py
+++ b/api/services.py
@@ -14,7 +14,7 @@ from authenticator import Authenticator
 from overdrive import OverdriveAPI
 from threem import ThreeMAPI
 from axis import Axis360API
-#from enki import EnkiAPI
+from enki import EnkiAPI
 from circulation import CirculationAPI
 
 class ServiceStatus(object):
@@ -30,7 +30,7 @@ class ServiceStatus(object):
         self.overdrive = overdrive or OverdriveAPI.from_environment(self._db)
         self.threem = threem or ThreeMAPI.from_environment(self._db)
         self.axis = axis or Axis360API.from_environment(self._db)
-        self.enki = enki #or EnkiAPI.from_environment(self._db)
+        self.enki = enki or EnkiAPI.from_environment(self._db)
 
     def loans_status(self, response=False):
         """Checks the length of request times for patron activity.

--- a/api/services.py
+++ b/api/services.py
@@ -14,6 +14,7 @@ from authenticator import Authenticator
 from overdrive import OverdriveAPI
 from threem import ThreeMAPI
 from axis import Axis360API
+#from enki import EnkiAPI
 from circulation import CirculationAPI
 
 class ServiceStatus(object):
@@ -23,12 +24,13 @@ class ServiceStatus(object):
 
     SUCCESS_MSG = re.compile('^SUCCESS: ([0-9]+.[0-9]+)sec')
 
-    def __init__(self, _db, auth=None, overdrive=None, threem=None, axis=None):
+    def __init__(self, _db, auth=None, overdrive=None, threem=None, axis=None, enki=None):
         self._db = _db
         self.auth = auth or Authenticator.from_config(self._db)
         self.overdrive = overdrive or OverdriveAPI.from_environment(self._db)
         self.threem = threem or ThreeMAPI.from_environment(self._db)
         self.axis = axis or Axis360API.from_environment(self._db)
+        self.enki = enki #or EnkiAPI.from_environment(self._db)
 
     def loans_status(self, response=False):
         """Checks the length of request times for patron activity.
@@ -70,7 +72,7 @@ class ServiceStatus(object):
             self.log.error(error)
             status[service] = error
             return status
-        for api in [self.overdrive, self.threem, self.axis]:
+        for api in [self.overdrive, self.threem, self.axis, self.enki]:
             if not api:
                 continue
             name = api.source.name
@@ -96,7 +98,7 @@ class ServiceStatus(object):
         patron, password = self.get_patron()
         api = CirculationAPI(
             self._db, overdrive=self.overdrive, threem=self.threem,
-            axis=self.axis
+            axis=self.axis, enki=self.enki
         )
 
         license_pool = identifier.licensed_through

--- a/bin/enki_monitor
+++ b/bin/enki_monitor
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""Monitor the Enki collection by asking about recently changed books."""
+import os
+import sys
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..")
+sys.path.append(os.path.abspath(package_dir))
+from core.scripts import RunMonitorScript
+from api.enki import EnkiCirculationMonitor
+RunMonitorScript(EnkiCirculationMonitor).run()


### PR DESCRIPTION
Adds the basic support to ingest Enki content and show in the circulation manager feed. This operates in conjunction with work done in server_core.